### PR TITLE
Refactor getRemotes to preserve git remote order

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,22 +132,22 @@ func getRemotes() ([]Remote, error) {
 	if err != nil {
 		return nil, err
 	}
-	
-	remoteMap := make(map[string]string)
+
+	seen := make(map[string]bool)
+	var remotes []Remote
 	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	
+
 	for _, line := range lines {
 		parts := strings.Fields(line)
 		if len(parts) >= 2 && strings.HasSuffix(line, "(fetch)") {
-			remoteMap[parts[0]] = parts[1]
+			name := parts[0]
+			if !seen[name] {
+				seen[name] = true
+				remotes = append(remotes, Remote{Name: name, URL: parts[1]})
+			}
 		}
 	}
-	
-	var remotes []Remote
-	for name, url := range remoteMap {
-		remotes = append(remotes, Remote{Name: name, URL: url})
-	}
-	
+
 	return remotes, nil
 }
 


### PR DESCRIPTION
## Summary
Refactored the `getRemotes()` function to preserve the order of git remotes as returned by `git remote -v`, rather than relying on map iteration which has undefined ordering in Go.

## Key Changes
- Replaced `map[string]string` with a slice-based approach to maintain insertion order
- Introduced a `seen` map to track already-processed remotes and prevent duplicates
- Remotes are now appended directly to the result slice during iteration, eliminating the need for a second loop
- Cleaned up unnecessary whitespace

## Implementation Details
The previous implementation used a map to store remotes, then iterated over that map to build the final slice. Since Go maps have undefined iteration order, this could result in remotes being returned in a different order than they appear in the git configuration. The new implementation processes remotes in order while still deduplicating entries using a boolean tracking map.

https://claude.ai/code/session_01R9FXPvRV7g8esjxbSSpMrS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved git remote parsing with better handling of duplicate remote names. The system now reliably preserves the first-seen fetch URL for each remote, ensuring consistent behavior and ordering when managing multiple entries with identical names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->