### PR TITLE
Update softprops/action-gh-release from v1 to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           path: ./artifacts
       
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: ./artifacts/*/*
           draft: false


### PR DESCRIPTION
## Summary
- Bump `softprops/action-gh-release` from `v1` to `v2` in `.github/workflows/release.yml`
- `v1` runs on Node.js 16 and may trigger GitHub Actions deprecation warnings; `v2` runs on Node.js 20
- All inputs currently used (`files`, `draft`, `prerelease`, `generate_release_notes`) remain compatible in `v2`

## Test plan
- [ ] Push a new version tag (e.g. `v0.x.y`) and confirm the release workflow completes successfully and uploads all artifacts

Closes #14

Generated with [Claude Code](https://claude.com/claude-code)