### PR TITLE
Capture stderr in runGitSilent for diagnosable failures

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
@@ -341,7 +342,19 @@ func getCommitSHA(ref string) string {
 func runGitSilent(args ...string) error {
 	verboseLog("git", args)
 	cmd := exec.Command("git", args...)
-	return cmd.Run()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if verbose && msg != "" {
+			fmt.Fprintln(os.Stderr, msg)
+		}
+		if msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+	}
+	return err
 }
 
 func verboseLog(cmd string, args []string) {


### PR DESCRIPTION
## Summary
- `runGitSilent` discarded stderr, so git failures left users with no diagnostic information.
- Capture stderr into a buffer and include the message in the returned error (and echo it when `--verbose` is set) so callers and users can see why a git command failed.

Closes #9

## Test plan
- [x] `go build -o gh-sync .`
- [x] `go test ./...`
- [x] `go vet ./...`