### PR TITLE
Fix verboseLog ignoring --color flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -381,7 +381,7 @@ func runGitSilent(colors colorConfig, args ...string) error {
 func verboseLog(colors colorConfig, cmd string, args []string) {
 	if verbose {
 		msg := fmt.Sprintf("$ %s %s", cmd, strings.Join(args, " "))
-		if isatty.IsTerminal(os.Stderr.Fd()) && colors.magenta != "" {
+		if colors.magenta != "" {
 			msg = fmt.Sprintf("%s%s%s", colors.magenta, msg, colors.reset)
 		}
 		fmt.Fprintln(os.Stderr, msg)


### PR DESCRIPTION
## Summary
- `verboseLog` independently checked `isatty.IsTerminal(os.Stderr.Fd())` and ignored the `--color` flag, so `--color=always` did not colorize verbose output when stderr was piped.
- Drop the redundant stderr tty check and rely on the global `magenta` variable, which `colorizeOutput()` already clears when color is disabled. This unifies color handling with the rest of the program.

## Test plan
- [x] `go build -o gh-sync .`
- [x] `go test ./...`
- [ ] Manual: `./gh-sync --verbose --color=always 2>&1 | cat` shows magenta-colored verbose lines
- [ ] Manual: `./gh-sync --verbose --color=never` shows uncolored verbose lines

Closes #10