### PR TITLE
Reject invalid --color values

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,14 @@ func main() {
 	}
 	flag.Parse()
 
+	// Validate --color value
+	switch colorFlag {
+	case "always", "never", "auto":
+	default:
+		fmt.Fprintf(os.Stderr, "fatal: invalid --color value: %q (must be one of: always, never, auto)\n", colorFlag)
+		os.Exit(1)
+	}
+
 	// Set up color output
 	colorize := colorizeOutput()
 	if !colorize {


### PR DESCRIPTION
## Summary
- Validate `--color` after `flag.Parse()` and exit with a clear error when the value isn't one of `always`, `never`, `auto`.
- Previously, typos like `--color=alwyas` were silently treated as `auto` because `colorizeOutput`'s default case mirrored `auto`.

Closes #12

## Test plan
- [x] `go build -o gh-sync .`
- [x] `./gh-sync --color=foo` exits 1 with `fatal: invalid --color value: "foo" (must be one of: always, never, auto)`
- [x] `./gh-sync --color=alwyas` (the typo from the issue) exits 1 with the same error
- [x] `./gh-sync --color=always` / `--color=never` / `--color=auto` continue to work
- [x] `go test ./...` passes