### PR TITLE
build(deps): update Go to 1.26.3 and bump dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.26'
       
       - name: Build binary
         env:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/him0/gh-sync
 
-go 1.21
+go 1.26.3
 
-require github.com/mattn/go-isatty v0.0.20
+require github.com/mattn/go-isatty v0.0.22
 
-require golang.org/x/sys v0.6.0 // indirect
+require golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
+github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Summary
- `go.mod` の Go バージョンを `1.21` → `1.26.3` に更新
- 依存ライブラリを最新化: `mattn/go-isatty` v0.0.20 → v0.0.22、`golang.org/x/sys` v0.6.0 → v0.45.0
- `.github/workflows/release.yml` の `setup-go` を `1.26` に揃える

## Test plan
- [x] `go mod tidy` が通る
- [x] `go build -o gh-sync .` が成功する
- [x] バイナリの `--help` 出力に変化がない
- [ ] CI (Release workflow) がタグプッシュ時に通ることをリリース時に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)